### PR TITLE
Prefer Europe/London timezone

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,14 @@
 Package: weva
 Title: A Tiny Weather-Report CLI
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: 
     person("Matt", "Dray", , "mwdray+weva@gmail.com", role = c("aut", "cre"))
-Description: A tiny opinionated command-line interface (CLI) to fetch
-    weather information from the 'Open-Meteo' API and present it as a
-    single-line in the terminal.
+Description: A limited and opinionated command-line interface (CLI) to
+    fetch weather information for a UK postcode from the 'Open-Meteo' API
+    and present it as a single-line in the terminal.
 License: MIT + file LICENSE
+URL: https://github.com/matt-dray/weva
+BugReports: https://github.com/matt-dray/weva/issues
 Imports: 
     httr2,
     lubridate,

--- a/R/api.R
+++ b/R/api.R
@@ -67,7 +67,7 @@ prepare_report <- function(
   units <- response[["current_units"]][["temperature_2m"]]
 
   current_time_rounded <- current[["time"]] |>
-    lubridate::ymd_hm(tz = "GMT") |>
+    lubridate::ymd_hm(tz = "Europe/London") |>
     lubridate::round_date("hour") |>
     format("%Y-%m-%dT%H:%M")
   current_index <- match(current_time_rounded, hourly[["time"]])
@@ -96,10 +96,10 @@ prepare_report <- function(
   if (show_datetimes) {
     format_string <- "%Y-%m-%d %H:%M"
     dt_now <- current[["time"]] |>
-      lubridate::ymd_hm(tz = "GMT") |>
+      lubridate::ymd_hm(tz = "Europe/London") |>
       format(format_string)
     dt_later <- hourly[["time"]][[index_later]] |>
-      lubridate::ymd_hm(tz = "GMT") |>
+      lubridate::ymd_hm(tz = "Europe/London") |>
       format(format_string)
 
     # fmt: skip
@@ -116,7 +116,9 @@ prepare_report <- function(
 
     when <- ifelse(
       show_datetimes,
-      current[["time"]] |> lubridate::ymd_hm(tz = "GMT") |> format("%Y-%m-%d"),
+      current[["time"]] |>
+        lubridate::ymd_hm(tz = "Europe/London") |>
+        format("%Y-%m-%d"),
       "today"
     )
 
@@ -209,7 +211,7 @@ as_emoji <- function(weather_code) {
 #'
 #' @param postcode Character scalar. A valid UK postcode.
 #' @details
-#' - Fixed for timezone GMT.
+#' - Fixed for timezone Europe/London.
 #' - Fixed to a three-day forecast (inclusive of today).
 #' - Data fetched from the 'Open-Meteo' API:
 #'   - current `temperature_2m` and `weather_code`
@@ -244,7 +246,7 @@ build_request <- function(postcode) {
     httr2::req_url_query(
       latitude = geo[["lat"]],
       longitude = geo[["lon"]],
-      timezone = "GMT",
+      timezone = "Europe/London",
       forecast_days = 3L,
       current = paste("temperature_2m", "weather_code", sep = ","),
       hourly = paste("temperature_2m", "weather_code", sep = ","),

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https:
 [![R-CMD-check](https://github.com/matt-dray/hext/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/matt-dray/hext/actions/workflows/R-CMD-check.yaml)
 [![format-check.yaml](https://github.com/matt-dray/hext/actions/workflows/format.yaml/badge.svg)](https://github.com/matt-dray/hext/actions/workflows/format.yaml)
 [![jarl-check](https://github.com/matt-dray/hext/actions/workflows/lint.yaml/badge.svg)](https://github.com/matt-dray/hext/actions/workflows/lint.yaml)
+[![Blog
+posts](https://img.shields.io/badge/rostrum.blog-posts-008900?labelColor=000000&logo=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhEAAQAPEAAAAAABWCBAAAAAAAACH5BAlkAAIAIf8LTkVUU0NBUEUyLjADAQAAACwAAAAAEAAQAAAC55QkISIiEoQQQgghRBBCiCAIgiAIgiAIQiAIgSAIgiAIQiAIgRAEQiAQBAQCgUAQEAQEgYAgIAgIBAKBQBAQCAKBQEAgCAgEAoFAIAgEBAKBIBAQCAQCgUAgEAgCgUBAICAgICAgIBAgEBAgEBAgEBAgECAgICAgECAQIBAQIBAgECAgICAgICAgECAQECAQICAgICAgICAgEBAgEBAgEBAgICAgICAgECAQIBAQIBAgECAgICAgIBAgECAQECAQIBAgICAgIBAgIBAgEBAgECAgECAgICAgICAgECAgECAgQIAAAQIKAAAh%2BQQJZAACACwAAAAAEAAQAAAC55QkIiESIoQQQgghhAhCBCEIgiAIgiAIQiAIgSAIgiAIQiAIgRAEQiAQBAQCgUAQEAQEgYAgIAgIBAKBQBAQCAKBQEAgCAgEAoFAIAgEBAKBIBAQCAQCgUAgEAgCgUBAICAgICAgIBAgEBAgEBAgEBAgECAgICAgECAQIBAQIBAgECAgICAgICAgECAQECAQICAgICAgICAgEBAgEBAgEBAgICAgICAgECAQIBAQIBAgECAgICAgIBAgECAQECAQIBAgICAgIBAgIBAgEBAgECAgECAgICAgICAgECAgECAgQIAAAQIKAAA7)](https://www.rostrum.blog/index.html#category=weva)
 <!-- badges: end -->
 
 > [!NOTE]
@@ -52,7 +54,7 @@ You can also supply options to:
 
 * extend the 'later' forecast by a user-supplied number of `--hours` (shortcut `-h`)
 * show interpreted `--datetimes` (`-d`) for each segment, rather than simple text
-* show today's `--extremes` (`-e`) of temperature.
+* show today's `--extremes` (`-e`) of temperature
 
 ```bash
 weva "WC2N 5DU" -h 24 -d -e

--- a/man/get_weather.Rd
+++ b/man/get_weather.Rd
@@ -18,7 +18,7 @@ postcode that is interpretable by the 'postcodes.io' API.
 }
 \details{
 \itemize{
-\item Fixed for timezone GMT.
+\item Fixed for timezone Europe/London.
 \item Fixed to a three-day forecast (inclusive of today).
 \item Data fetched from the 'Open-Meteo' API:
 \itemize{

--- a/man/weva-package.Rd
+++ b/man/weva-package.Rd
@@ -6,7 +6,15 @@
 \alias{weva-package}
 \title{weva: A Tiny Weather-Report CLI}
 \description{
-A tiny opinionated command-line interface (CLI) to fetch weather information from the 'Open-Meteo' API and present it as a single-line in the terminal.
+A limited and opinionated command-line interface (CLI) to fetch weather information for a UK postcode from the 'Open-Meteo' API and present it as a single-line in the terminal.
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/matt-dray/weva}
+  \item Report bugs at \url{https://github.com/matt-dray/weva/issues}
+}
+
 }
 \author{
 \strong{Maintainer}: Matt Dray \email{mwdray+weva@gmail.com}


### PR DESCRIPTION
Close #16.

* Replace `"GMT"` with `"Europe/London"` throughout.
* Tweak documentation.